### PR TITLE
Remove `supported_mime_types` from instance statuses config and update spec

### DIFF
--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -71,7 +71,6 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
         max_characters: StatusLengthValidator::MAX_CHARS,
         max_media_attachments: Status::MEDIA_ATTACHMENTS_LIMIT,
         characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
-        supported_mime_types: HtmlAwareFormatter::STATUS_MIME_TYPES,
       },
 
       media_attachments: {

--- a/spec/requests/api/v1/instance_spec.rb
+++ b/spec/requests/api/v1/instance_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe 'Instances' do
         expect(response.parsed_body)
           .to be_present
           .and include(title: 'Mastodon')
+          .and include(
+            configuration: include(
+              statuses: include(
+                max_characters: StatusLengthValidator::MAX_CHARS,
+                max_media_attachments: Status::MEDIA_ATTACHMENTS_LIMIT,
+                characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS
+              )
+            )
+          )
       end
     end
 


### PR DESCRIPTION
### Motivation
- Stop exposing `supported_mime_types` for statuses in the instance API payload (to avoid duplicating or leaking `HtmlAwareFormatter::STATUS_MIME_TYPES`) and keep the API configuration focused on status limits.

### Description
- Remove the `supported_mime_types: HtmlAwareFormatter::STATUS_MIME_TYPES` entry from the `statuses` block in `app/serializers/rest/v1/instance_serializer.rb` and update `spec/requests/api/v1/instance_spec.rb` to assert the remaining `statuses` configuration keys are present in the response.

### Testing
- Ran the updated request spec with `bundle exec rspec spec/requests/api/v1/instance_spec.rb` and the examples passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d78a984bc832199320ebc7e1616f4)